### PR TITLE
ScummVM Korean Patch + AGS Games Enable

### DIFF
--- a/packages/emulators/standalone/scummvmsa/package.mk
+++ b/packages/emulators/standalone/scummvmsa/package.mk
@@ -7,7 +7,7 @@ PKG_VERSION="6378050357807502d47a5291cf53a38f4a18d9d0"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://github.com/british-choi/scummvm"
 PKG_URL="${PKG_SITE}.git"
-PKG_DEPENDS_TARGET="toolchain SDL2 SDL2_net freetype fluidsynth soundfont-generaluser pipewire"
+PKG_DEPENDS_TARGET="toolchain SDL2 SDL2_net freetype fluidsynth soundfont-generaluser pipewire libmad libtheora"
 PKG_LONGDESC="Script Creation Utility for Maniac Mansion Virtual Machine"
 
 pre_configure_target() { 

--- a/packages/emulators/standalone/scummvmsa/patches/000-touch-support.patch
+++ b/packages/emulators/standalone/scummvmsa/patches/000-touch-support.patch
@@ -596,10 +596,11 @@ new mode 100644
 diff --git a/backends/platform/maemo/debian/rules b/backends/platform/maemo/debian/rules
 old mode 100755
 new mode 100644
-diff -rupN scummvmsa.orig/backends/platform/sdl/sdl.cpp scummvmsa/backends/platform/sdl/sdl.cpp
---- scummvmsa.orig/backends/platform/sdl/sdl.cpp	2024-05-22 17:48:06.668512302 +0900
-+++ scummvmsa/backends/platform/sdl/sdl.cpp	2024-05-22 18:01:41.315157079 +0900
-@@ -201,6 +201,9 @@ bool OSystem_SDL::hasFeature(Feature f)
+diff --git a/backends/platform/sdl/sdl.cpp b/backends/platform/sdl/sdl.cpp
+index 8cd8bba06d2..5ff69f3905f 100644
+--- a/backends/platform/sdl/sdl.cpp
++++ b/backends/platform/sdl/sdl.cpp
+@@ -201,6 +201,9 @@ bool OSystem_SDL::hasFeature(Feature f) {
  	if (f == kFeatureJoystickDeadzone || f == kFeatureKbdMouseSpeed) {
  		return _eventSource->isJoystickConnected();
  	}
@@ -609,7 +610,7 @@ diff -rupN scummvmsa.orig/backends/platform/sdl/sdl.cpp scummvmsa/backends/platf
  #if defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
  	/* Even if we are using the 2D graphics manager,
  	 * we are at one initGraphics3d call of supporting OpenGL */
-@@ -213,6 +216,29 @@ bool OSystem_SDL::hasFeature(Feature f)
+@@ -213,6 +216,29 @@ bool OSystem_SDL::hasFeature(Feature f) {
  	return ModularGraphicsBackend::hasFeature(f);
  }
  
@@ -639,24 +640,25 @@ diff -rupN scummvmsa.orig/backends/platform/sdl/sdl.cpp scummvmsa/backends/platf
  void OSystem_SDL::initBackend() {
  	// Check if backend has not been initialized
  	assert(!_inited);
-diff -rupN scummvmsa.orig/backends/platform/sdl/sdl.h scummvmsa/backends/platform/sdl/sdl.h
---- scummvmsa.orig/backends/platform/sdl/sdl.h	2024-05-22 17:48:06.668512302 +0900
-+++ scummvmsa/backends/platform/sdl/sdl.h	2024-05-22 18:01:57.223512196 +0900
-@@ -53,6 +53,11 @@ public:
+diff --git a/backends/platform/sdl/sdl.h b/backends/platform/sdl/sdl.h
+index 1315ae9b7fe..376e1b3cae0 100644
+--- a/backends/platform/sdl/sdl.h
++++ b/backends/platform/sdl/sdl.h
+@@ -52,6 +52,10 @@ public:
+ 	void init() override;
  
  	bool hasFeature(Feature f) override;
- 
 +#if defined(USE_SDL_TS_VMOUSE)
 +	void setFeatureState(Feature f, bool enable) override;
 +	bool getFeatureState(Feature f) override;
 +#endif // defined(USE_SDL_TS_VMOUSE)
-+
+ 
  	// Override functions from ModularBackend and OSystem
  	void initBackend() override;
- 	void engineInit() override;
-diff -rupN scummvmsa.orig/configure scummvmsa/configure
---- scummvmsa.orig/configure	2024-05-22 17:48:06.700513064 +0900
-+++ scummvmsa/configure	2024-05-22 18:07:12.178134975 +0900
+diff --git a/configure b/configure
+index 480916a2706..8de5c65791c 100755
+--- a/configure
++++ b/configure
 @@ -226,6 +226,7 @@ _nuked_opl=yes
  _builtin_resources=yes
  _windows_console=yes
@@ -665,25 +667,25 @@ diff -rupN scummvmsa.orig/configure scummvmsa/configure
  _cygwin_build=no
  _ext_sse2=auto
  _ext_avx2=auto
-@@ -986,6 +987,8 @@ Optional Features:
-   --disable-windows-console do not show console output on Windows
-   --enable-windows-unicode  use Windows Unicode APIs (default)
-   --disable-windows-unicode use Windows ANSI APIs
-+  --enable-sdl-ts-vmouse   enable SDL touchscreen virtual mouse support
-+  --disable-sdl-ts-vmouse  disable SDL touchscreen virtual mouse support
+@@ -989,6 +990,8 @@ Optional Features:
    --enable-ext-sse2         allow code to use sse2 extensions on x86/amd64
    --enable-ext-avx2         allow code to use avx2 extensions on x86/amd64
    --enable-ext-neon         allow code to use neon extensions on ARM
-@@ -1307,6 +1310,8 @@ for ac_option in $@; do
- 	--disable-eventrecorder)     _eventrec=no            ;;
- 	--enable-text-console)       _text_console=yes       ;;
- 	--disable-text-console)      _text_console=no        ;;
++  --enable-sdl-ts-vmouse   enable SDL touchscreen virtual mouse support
++  --disable-sdl-ts-vmouse  disable SDL touchscreen virtual mouse support
+ 
+ Optional Documentation Options:
+   --with-manual-version=VERSION version to use when generating the manual (optional)
+@@ -1313,6 +1316,8 @@ for ac_option in $@; do
+	--disable-ext-avx2)          _ext_avx2=no            ;;
+	--enable-ext-neon)           _ext_neon=yes           ;;
+	--disable-ext-neon)          _ext_neon=no            ;;
 +	--enable-sdl-ts-vmouse)      _sdl_ts_vmouse=yes      ;;
 +	--disable-sdl-ts-vmouse)     _sdl_ts_vmouse=no       ;;
- 	--enable-ext-sse2)           _ext_sse2=yes           ;;
- 	--disable-ext-sse2)          _ext_sse2=no            ;;
- 	--enable-ext-avx2)           _ext_avx2=yes           ;;
-@@ -6075,6 +6080,9 @@ define_in_config_h_if_yes "$_readline" '
+ 	--with-fluidsynth-prefix=*)
+ 		arg=`echo $ac_option | cut -d '=' -f 2`
+ 		FLUIDSYNTH_CFLAGS="-I$arg/include"
+@@ -6075,6 +6080,9 @@ define_in_config_h_if_yes "$_readline" 'USE_READLINE'
  
  define_in_config_h_if_yes "$_text_console" 'USE_TEXT_CONSOLE_FOR_DEBUGGER'
  

--- a/packages/multimedia/libtheora/package.mk
+++ b/packages/multimedia/libtheora/package.mk
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+
+PKG_NAME="libtheora"
+PKG_VERSION="1.1.1"
+PKG_SHA256="b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
+PKG_LICENSE="GPL"
+PKG_SITE="http://downloads.xiph.org/releases/theora"
+PKG_URL="${PKG_SITE}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"
+PKG_BUILD_DEPENDS="libogg libvorbis host-pkgconf"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="On2's VP3 codec"
+PKG_TOOLCHAIN="autotools"
+
+# package specific configure options
+PKG_CONFIGURE_OPTS_TARGET="--disable-examples --disable-oggtest --disable-vorbistest --disable-sdltest --enable-static --disable-shared --disable-spec"
+
+post_makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  cat > ${SYSROOT_PREFIX}/usr/lib/pkgconfig/theora.pc << "EOF"
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: thoera
+Description: MPEG video decoder
+Requires:
+Version: 1.1.1
+Libs: -L${libdir} -ltheora
+Cflags: -I${includedir}
+EOF
+}

--- a/packages/multimedia/libtheora/patches/0001-link-libtheoradec.patch
+++ b/packages/multimedia/libtheora/patches/0001-link-libtheoradec.patch
@@ -1,0 +1,21 @@
+libtheoraenc.so needs to be linked to libtheoradec.so in order to avoid
+
+symbol 'th_comment_query_count': can't resolve symbol in lib '/usr/lib/libtheoraenc.so.1'
+
+when starting Freeswitch.
+
+Patch downloaded from
+http://www.sisyphus.ru/en/srpm/Sisyphus/libtheora/patches/0
+
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+
+--- libtheora/lib/Makefile.am
++++ libtheora/lib/Makefile.am
+@@ -153,6 +153,7 @@ libtheoraenc_la_SOURCES = \
+ libtheoraenc_la_LDFLAGS = \
+   -version-info @THENC_LIB_CURRENT@:@THENC_LIB_REVISION@:@THENC_LIB_AGE@ \
+   @THEORAENC_LDFLAGS@ $(OGG_LIBS)
++libtheoraenc_la_LIBADD = libtheoradec.la
+ 
+ libtheora_la_SOURCES = \
+ 	$(decoder_sources) \

--- a/packages/multimedia/libtheora/patches/0002-fix-autoreconf.patch
+++ b/packages/multimedia/libtheora/patches/0002-fix-autoreconf.patch
@@ -1,0 +1,46 @@
+Fix broken autoreconf
+
+Downloaded from upstream git
+https://git.xiph.org/?p=theora.git;a=commitdiff;h=28cc6dbd9b2a141df94f60993256a5fca368fa54
+
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+
+
+From: Tim Terriberry <tterribe@xiph.org>
+Date: Fri, 20 May 2011 20:41:50 +0000 (+0000)
+Subject: Make autoreconf -i -f work.
+X-Git-Url: https://git.xiph.org/?p=theora.git;a=commitdiff_plain;h=28cc6dbd9b2a141df94f60993256a5fca368fa54
+
+Make autoreconf -i -f work.
+
+Patch from David Schleef.
+
+svn path=/trunk/theora/; revision=17990
+---
+
+diff --git a/Makefile.am b/Makefile.am
+index 89fd753..1783857 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -4,6 +4,8 @@
+ #AUTOMAKE_OPTIONS = foreign 1.7 dist-zip dist-bzip2
+ AUTOMAKE_OPTIONS = foreign 1.11 dist-zip dist-xz
+ 
++ACLOCAL_AMFLAGS=-I m4
++
+ if THEORA_ENABLE_EXAMPLES
+ EXAMPLES_DIR = examples
+ else
+diff --git a/configure.ac b/configure.ac
+index 1cbec1a..456b603 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -68,7 +68,7 @@ AC_LIBTOOL_WIN32_DLL
+ AM_PROG_LIBTOOL
+ 
+ dnl Add parameters for aclocal
+-AC_SUBST(ACLOCAL_AMFLAGS, "-I m4")
++AC_CONFIG_MACRO_DIR([m4])
+ 
+ dnl Check for doxygen
+ AC_ARG_ENABLE([doc],

--- a/packages/tools/sound/libmad/package.mk
+++ b/packages/tools/sound/libmad/package.mk
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+
+PKG_NAME="libmad"
+PKG_VERSION="0.15.1b"
+PKG_SHA256="bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.mars.org/home/rob/proj/mpeg/"
+PKG_URL="${SOURCEFORGE_SRC}/mad/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="A high-quality MPEG audio decoder."
+PKG_TOOLCHAIN="autotools"
+
+# package specific configure options
+PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+if [ "${TARGET_ARCH}" = "x86_64" ] ; then
+  PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} --enable-accuracy --enable-fpm=64bit"
+fi
+
+post_makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/pkgconfig
+  cat > ${SYSROOT_PREFIX}/usr/lib/pkgconfig/mad.pc << "EOF"
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: mad
+Description: MPEG audio decoder
+Requires:
+Version: 0.15.1b
+Libs: -L${libdir} -lmad
+Cflags: -I${includedir}
+EOF
+}

--- a/packages/tools/sound/libmad/patches/libmad-0.15.1b-automake_1.13.patch
+++ b/packages/tools/sound/libmad/patches/libmad-0.15.1b-automake_1.13.patch
@@ -1,0 +1,12 @@
+diff -Naur libmad-0.15.1b-old/configure.ac libmad-0.15.1b-new/configure.ac
+--- libmad-0.15.1b-old/configure.ac	2004-01-23 01:41:32.000000000 -0800
++++ libmad-0.15.1b-new/configure.ac	2012-12-30 15:14:37.000000000 -0800
+@@ -28,7 +28,7 @@
+ 
+ AM_INIT_AUTOMAKE
+ 
+-AM_CONFIG_HEADER([config.h])
++AC_CONFIG_HEADERS([config.h])
+ 
+ dnl System type.
+ 

--- a/packages/tools/sound/libmad/patches/libmad-0.15.1b-cflags-O2.patch
+++ b/packages/tools/sound/libmad/patches/libmad-0.15.1b-cflags-O2.patch
@@ -1,0 +1,12 @@
+diff -Naur libmad-0.15.1b-orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b-orig/configure.ac	2007-07-01 12:58:13.000000000 -0600
++++ libmad-0.15.1b/configure.ac	2007-07-01 12:59:13.000000000 -0600
+@@ -105,7 +105,7 @@
+ 	    shift
+ 	    ;;
+ 	-O2)
+-	    optimize="-O"
++	    optimize="-O2"
+ 	    shift
+ 	    ;;
+ 	-fomit-frame-pointer)

--- a/packages/tools/sound/libmad/patches/libmad-0.15.1b-cflags.patch
+++ b/packages/tools/sound/libmad/patches/libmad-0.15.1b-cflags.patch
@@ -1,0 +1,146 @@
+diff -Naur libmad-0.15.1b-orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b-orig/configure.ac	2007-06-30 20:22:31.000000000 -0600
++++ libmad-0.15.1b/configure.ac	2007-06-30 20:25:31.000000000 -0600
+@@ -122,74 +122,74 @@
+     esac
+ done
+ 
+-if test "$GCC" = yes
+-then
+-    if test -z "$arch"
+-    then
+-	case "$host" in
+-	    i386-*)           ;;
+-	    i?86-*)           arch="-march=i486" ;;
+-	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
+-	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
+-	    powerpc-*)        ;;
+-	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
+-	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
+-	esac
+-    fi
+-
+-    case "$optimize" in
+-	-O|"-O "*)
+-	    optimize="-O"
+-	    optimize="$optimize -fforce-mem"
+-	    optimize="$optimize -fforce-addr"
+-	    : #x optimize="$optimize -finline-functions"
+-	    : #- optimize="$optimize -fstrength-reduce"
+-	    optimize="$optimize -fthread-jumps"
+-	    optimize="$optimize -fcse-follow-jumps"
+-	    optimize="$optimize -fcse-skip-blocks"
+-	    : #x optimize="$optimize -frerun-cse-after-loop"
+-	    : #x optimize="$optimize -frerun-loop-opt"
+-	    : #x optimize="$optimize -fgcse"
+-	    optimize="$optimize -fexpensive-optimizations"
+-	    optimize="$optimize -fregmove"
+-	    : #* optimize="$optimize -fdelayed-branch"
+-	    : #x optimize="$optimize -fschedule-insns"
+-	    optimize="$optimize -fschedule-insns2"
+-	    : #? optimize="$optimize -ffunction-sections"
+-	    : #? optimize="$optimize -fcaller-saves"
+-	    : #> optimize="$optimize -funroll-loops"
+-	    : #> optimize="$optimize -funroll-all-loops"
+-	    : #x optimize="$optimize -fmove-all-movables"
+-	    : #x optimize="$optimize -freduce-all-givs"
+-	    : #? optimize="$optimize -fstrict-aliasing"
+-	    : #* optimize="$optimize -fstructure-noalias"
+-
+-	    case "$host" in
+-		arm*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		mips*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    optimize="$optimize -finline-functions"
+-		    ;;
+-		i?86-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		powerpc-apple-*)
+-		    # this triggers an internal compiler error with gcc2
+-		    : #optimize="$optimize -fstrength-reduce"
+-
+-		    # this is really only beneficial with gcc3
+-		    : #optimize="$optimize -finline-functions"
+-		    ;;
+-		*)
+-		    # this sometimes provokes bugs in gcc 2.95.2
+-		    : #optimize="$optimize -fstrength-reduce"
+-		    ;;
+-	    esac
+-	    ;;
+-    esac
+-fi
++#if test "$GCC" = yes
++#then
++#    if test -z "$arch"
++#    then
++#	case "$host" in
++#	    i386-*)           ;;
++#	    i?86-*)           arch="-march=i486" ;;
++#	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
++#	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
++#	    powerpc-*)        ;;
++#	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
++#	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
++#	esac
++#    fi
++#
++#    case "$optimize" in
++#	-O|"-O "*)
++#	    optimize="-O"
++#	    optimize="$optimize -fforce-mem"
++#	    optimize="$optimize -fforce-addr"
++#	    : #x optimize="$optimize -finline-functions"
++#	    : #- optimize="$optimize -fstrength-reduce"
++#	    optimize="$optimize -fthread-jumps"
++#	    optimize="$optimize -fcse-follow-jumps"
++#	    optimize="$optimize -fcse-skip-blocks"
++#	    : #x optimize="$optimize -frerun-cse-after-loop"
++#	    : #x optimize="$optimize -frerun-loop-opt"
++#	    : #x optimize="$optimize -fgcse"
++#	    optimize="$optimize -fexpensive-optimizations"
++#	    optimize="$optimize -fregmove"
++#	    : #* optimize="$optimize -fdelayed-branch"
++#	    : #x optimize="$optimize -fschedule-insns"
++#	    optimize="$optimize -fschedule-insns2"
++#	    : #? optimize="$optimize -ffunction-sections"
++#	    : #? optimize="$optimize -fcaller-saves"
++#	    : #> optimize="$optimize -funroll-loops"
++#	    : #> optimize="$optimize -funroll-all-loops"
++#	    : #x optimize="$optimize -fmove-all-movables"
++#	    : #x optimize="$optimize -freduce-all-givs"
++#	    : #? optimize="$optimize -fstrict-aliasing"
++#	    : #* optimize="$optimize -fstructure-noalias"
++#
++#	    case "$host" in
++#		arm*-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    ;;
++#		mips*-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    optimize="$optimize -finline-functions"
++#		    ;;
++#		i?86-*)
++#		    optimize="$optimize -fstrength-reduce"
++#		    ;;
++#		powerpc-apple-*)
++#		    # this triggers an internal compiler error with gcc2
++#		    : #optimize="$optimize -fstrength-reduce"
++#
++#		    # this is really only beneficial with gcc3
++#		    : #optimize="$optimize -finline-functions"
++#		    ;;
++#		*)
++#		    # this sometimes provokes bugs in gcc 2.95.2
++#		    : #optimize="$optimize -fstrength-reduce"
++#		    ;;
++#	    esac
++#	    ;;
++#    esac
++#fi
+ 
+ case "$host" in
+     mips*-agenda-*)


### PR DESCRIPTION
23일자 확인해보니 ScummVM의 AGS게임이 구동 안되더군요.

Jellos에 있던 라이브러리가 Rocknix로 넘어가면서 빠진거 같아요.

ScummVM 게임을 구동하기 위한 라이브러리 libmad libtheora 2개 추가했습니다.