### PR TITLE
Update ScummVM fix

### DIFF
--- a/packages/emulators/standalone/scummvmsa/package.mk
+++ b/packages/emulators/standalone/scummvmsa/package.mk
@@ -12,7 +12,7 @@ PKG_LONGDESC="Script Creation Utility for Maniac Mansion Virtual Machine"
 
 pre_configure_target() { 
   sed -i "s|sdl-config|sdl2-config|g" ${PKG_BUILD}/configure
-  TARGET_CONFIGURE_OPTS="--host=${TARGET_NAME} --backend=sdl --disable-alsa --with-sdl-prefix=${SYSROOT_PREFIX}/usr/bin --disable-debug --enable-release --enable-vkeybd --enable-sdl-ts-vmouse --opengl-mode=gles2"
+  TARGET_CONFIGURE_OPTS="--host=${TARGET_NAME} --backend=sdl --disable-alsa --with-sdl-prefix=${SYSROOT_PREFIX}/usr/bin --disable-debug --enable-release --enable-vkeybd --enable-sdl-ts-vmouse --opengl-mode=gles2 --disable-gtk"
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
0831일자에서 스컴이 실행 안되서 확인해본 결과
libgtk.so 파일을 찾는데 락닉스는 해당파일이 없습니다.

그래서 스컴 빌드시 gtk 없이 구동되게 패키지파일을 수정합니다.