### PR TITLE
Add SCI Korean patched Games

### DIFF
--- a/packages/emulators/standalone/scummvmsa/patches/003-sci-add-korean.patch
+++ b/packages/emulators/standalone/scummvmsa/patches/003-sci-add-korean.patch
@@ -6,7 +6,7 @@ index 2936c8424c0..28b629d483c 100644
  		// sometimes we need these to differentiate between localized versions.
  		addFileToDetectedGame("resource.aud", allFiles, md5Prop, game);
  		addFileToDetectedGame("resource.msg", allFiles, md5Prop, game);
-+		addFileToDetectedGame("resource.tex", allFiles, md5Prop, game);
++		addFileToDetectedGame("text.res", allFiles, md5Prop, game);
  	} else if (allFiles.contains("resmap.000") || allFiles.contains("resmap.001")) {
  		// add maps and volumes
  		for (int i = 0; i <= 7; i++) {
@@ -19,7 +19,7 @@ index 6b0279e2724..92abeea8805 100644
  		{"resource.001", 0, "13e81e1839cd7b216d2bb5615c1ca160", 796776},
  		{"resource.002", 0, "930e416bec196b9703a331d81b3d66f2", 1283812},
 -		{"resource.msg", 0, "71c6f480e742a0dd3700ec7825962921", 49538},
-+		{"resource.tex", 0, "71c6f480e742a0dd3700ec7825962921", 49538},
++		{"text.res", 0, "71c6f480e742a0dd3700ec7825962921", 49538},
  		AD_LISTEND},
  		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
  
@@ -43,7 +43,7 @@ index 6b0279e2724..92abeea8805 100644
  		{"resource.003", 0, "6f8d552b60ec82a165619a99e19c509d", 1078032},
  		{"resource.004", 0, "e114ce8f884601c43308fb5cbbea4874", 1174129},
  		{"resource.005", 0, "349ad9438172265d00680075c5a988d0", 1019669},
-+		{"resource.tex", 0, "2ab3703bac740dc34eedfed5d5c2610e", 102933},
++		{"text.res", 0, "2ab3703bac740dc34eedfed5d5c2610e", 102933},
  		AD_LISTEND},
 -		Common::JA_JPN, Common::kPlatformPC98, ADGF_ADDENGLISH, GUIO_STD16_HIRES	},
 +		Common::KO_KOR, Common::kPlatformPC98, ADGF_ADDENGLISH, GUIO_STD16_HIRES	},
@@ -63,7 +63,7 @@ index 6b0279e2724..92abeea8805 100644
 +		{"resource.002", 0, "6767f8c8585f617aaa91d442f41ae714", 1032989},
 +		{"resource.003", 0, "b1288e0821ee358d1ffe877e5900c8ec", 1047565},
 +		{"resource.004", 0, "f79daa70390d73746742ffcfc3dc4471", 937580},
-+		{"resource.tex", 0, "6a471b152556b7d39e38321fb2fbd2c9", 2948975},
++		{"text.res", 0, "6a471b152556b7d39e38321fb2fbd2c9", 2948975},
 +		AD_LISTEND},
 +		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
 +
@@ -80,7 +80,7 @@ index 6b0279e2724..92abeea8805 100644
 +	{"mothergoose256", "", {
 +		{"resource.map", 0, "52aae15e493cafd1da7e1c9b657a5bb9", 7026},
 +		{"resource.000", 0, "b7ecd8ae9e254e80310b5a668b276e6e", 2948975},
-+		{"resource.tex", 0, "3bb9104f7dc385fbc16605190af375cb", 2948975},
++		{"text.res", 0, "3bb9104f7dc385fbc16605190af375cb", 2948975},
 +		AD_LISTEND},
 +		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
  
@@ -111,7 +111,7 @@ index 59ae2119701..c654a1ba8ee 100644
  	addPatchDir(".");
 +	
 +	if (Common::File::exists("text.map"))
-+		addSource(new VolumeResourceSource("resource.tex", addExternalMap("text.map"), 0));
++		addSource(new VolumeResourceSource("text.res", addExternalMap("text.map"), 0));
  
  	if (Common::File::exists("message.map"))
  		addSource(new VolumeResourceSource("resource.msg", addExternalMap("message.map"), 0));

--- a/packages/emulators/standalone/scummvmsa/patches/003-sci-add-korean.patch
+++ b/packages/emulators/standalone/scummvmsa/patches/003-sci-add-korean.patch
@@ -1,0 +1,117 @@
+diff --git a/engines/sci/detection.cpp b/engines/sci/detection.cpp
+index 2936c8424c0..28b629d483c 100644
+--- a/engines/sci/detection.cpp
++++ b/engines/sci/detection.cpp
+@@ -271,6 +271,7 @@ ADDetectedGame SciMetaEngineDetection::fallbackDetect(const FileMap &allFiles, c
+ 		// sometimes we need these to differentiate between localized versions.
+ 		addFileToDetectedGame("resource.aud", allFiles, md5Prop, game);
+ 		addFileToDetectedGame("resource.msg", allFiles, md5Prop, game);
++		addFileToDetectedGame("resource.tex", allFiles, md5Prop, game);
+ 	} else if (allFiles.contains("resmap.000") || allFiles.contains("resmap.001")) {
+ 		// add maps and volumes
+ 		for (int i = 0; i <= 7; i++) {
+diff --git a/engines/sci/detection_tables.h b/engines/sci/detection_tables.h
+index 6b0279e2724..92abeea8805 100644
+--- a/engines/sci/detection_tables.h
++++ b/engines/sci/detection_tables.h
+@@ -157,7 +157,7 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 		{"resource.000", 0, "27ec5fa09cd12a7fd16e86d96a2ed245", 347071},
+ 		{"resource.001", 0, "13e81e1839cd7b216d2bb5615c1ca160", 796776},
+ 		{"resource.002", 0, "930e416bec196b9703a331d81b3d66f2", 1283812},
+-		{"resource.msg", 0, "71c6f480e742a0dd3700ec7825962921", 49538},
++		{"resource.tex", 0, "71c6f480e742a0dd3700ec7825962921", 49538},
+ 		AD_LISTEND},
+ 		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
+ 
+@@ -765,6 +765,15 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 		AD_LISTEND},
+ 		Common::EN_ANY, Common::kPlatformDOS, ADGF_CD, GUIO_STD16_SPEECH	},
+ 
++	// Freddy Pharkas - Korean CD DOS (from FRG)
++	// SCI interpreter version 1.001.132
++	{"freddypharkas", "CD", {
++		{"resource.map", 0, "d46b282f228a67ba13bd4b4009e95f8f", 6058},
++		{"resource.000", 0, "ee3c64ffff0ba9fb08bea2624631c598", 5490246},
++		{"resource.msg", 0, "c4d7026efba78d63673d6a058bd3a839", 561801},
++		AD_LISTEND},
++		Common::KO_KOR, Common::kPlatformDOS, ADGF_CD, GUIO_STD16_SPEECH	},
++
+ 	// Freddy Pharkas - English DOS Floppy (updated information from markcoolio in bug reports #4267 and #4286)
+ 	// Executable scanning reports "1.cfs.081"
+ 	// SCI interpreter version 1.001.132 (just a guess)
+@@ -2184,8 +2193,9 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 		{"resource.003", 0, "6f8d552b60ec82a165619a99e19c509d", 1078032},
+ 		{"resource.004", 0, "e114ce8f884601c43308fb5cbbea4874", 1174129},
+ 		{"resource.005", 0, "349ad9438172265d00680075c5a988d0", 1019669},
++		{"resource.tex", 0, "2ab3703bac740dc34eedfed5d5c2610e", 102933},
+ 		AD_LISTEND},
+-		Common::JA_JPN, Common::kPlatformPC98, ADGF_ADDENGLISH, GUIO_STD16_HIRES	},
++		Common::KO_KOR, Common::kPlatformPC98, ADGF_ADDENGLISH, GUIO_STD16_HIRES	},
+ 
+ 	// King's Quest 6 - English DOS Non-Interactive Demo
+ 	// Executable scanning reports "1.001.055", VERSION file reports "1.000.000"
+@@ -3753,6 +3763,19 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 		AD_LISTEND},
+ 		Common::EN_ANY, Common::kPlatformDOS, 0, GUIO_STD16	},
+ 
++	// Mixed-Up Fairy Tales v1.000 - English DOS (supplied by markcoolio in bug report #4271)
++	// Executable scanning reports "1.000.145"
++	{"fairytales", "", {
++		{"resource.map", 0, "9ae5aecc1cb797b11ea5cf0caeea272c", 3261},
++		{"resource.000", 0, "27ec5fa09cd12a7fd16e86d96a2ed245", 923685},
++		{"resource.001", 0, "49c8f7dcd9989e4491a93554bec325b0", 52324},
++		{"resource.002", 0, "6767f8c8585f617aaa91d442f41ae714", 1032989},
++		{"resource.003", 0, "b1288e0821ee358d1ffe877e5900c8ec", 1047565},
++		{"resource.004", 0, "f79daa70390d73746742ffcfc3dc4471", 937580},
++		{"resource.tex", 0, "6a471b152556b7d39e38321fb2fbd2c9", 2948975},
++		AD_LISTEND},
++		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
++
+ 	// Mixed-Up Fairy Tales - English DOS Floppy (from jvprat)
+ 	// Executable scanning reports "1.000.145", Floppy label reports "1.0, 11.13.91", VERSION file reports "1.000"
+ 	{"fairytales", "", {
+@@ -3802,6 +3825,15 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 		{"resource.000", 0, "b7ecd8ae9e254e80310b5a668b276e6e", 2948975},
+ 		AD_LISTEND},
+ 		Common::EN_ANY, Common::kPlatformDOS, 0, GUIO_STD16	},
++		
++	// Mixed-Up Mother Goose v2.000 - English DOS Floppy (supplied by markcoolio in bug report #4272)
++	// Executable scanning reports "1.001.031"
++	{"mothergoose256", "", {
++		{"resource.map", 0, "52aae15e493cafd1da7e1c9b657a5bb9", 7026},
++		{"resource.000", 0, "b7ecd8ae9e254e80310b5a668b276e6e", 2948975},
++		{"resource.tex", 0, "3bb9104f7dc385fbc16605190af375cb", 2948975},
++		AD_LISTEND},
++		Common::KO_KOR, Common::kPlatformDOS, 0, GUIO_STD16	},
+ 
+ 	// Mixed-Up Mother Goose - English DOS CD (from jvprat)
+ 	// Executable scanning reports "x.yyy.zzz"
+@@ -5813,12 +5845,12 @@ static const struct ADGameDescription SciGameDescriptions[] = {
+ 
+ 	// Space Quest 4 - Korean fan translation, based on English DOS CD (from the Space Quest Collection)
+ 	// Executable scanning reports "1.001.064", VERSION file reports "1.0"
+-	{"sq4", "", {
++	{"sq4", "CD", {
+ 		{"resource.map", 0, "ed90a8e3ccc53af6633ff6ab58392bae", 7054},
+ 		{"resource.000", 0, "63247e3901ab8963d4eece73747832e0", 5157378},
+ 		{"resource.msg", 0, "6ca82305ba1f8ac1cebdd20427168106", 561801},
+ 		AD_LISTEND},
+-		Common::KO_KOR, Common::kPlatformDOS, ADGF_CD, GUIO5(GAMEOPTION_SQ4_SILVER_CURSORS, GAMEOPTION_PREFER_DIGITAL_SFX, GAMEOPTION_ORIGINAL_SAVELOAD, GAMEOPTION_MIDI_MODE, GAMEOPTION_RGB_RENDERING)	},
++		Common::KO_KOR, Common::kPlatformDOS, ADGF_CD, GUIO_SQ4_CD	},
+ 
+ 	// Space Quest 4 - English DOS CD "NRS SQ4 Update 1.2" (unofficial patch)
+ 	// This patch set was distributed as a mixture the CD and floppy versions (the whole game)
+diff --git a/engines/sci/resource/resource.cpp b/engines/sci/resource/resource.cpp
+index 59ae2119701..c654a1ba8ee 100644
+--- a/engines/sci/resource/resource.cpp
++++ b/engines/sci/resource/resource.cpp
+@@ -720,6 +720,9 @@ int ResourceManager::addAppropriateSources() {
+ #endif
+ 
+ 	addPatchDir(".");
++	
++	if (Common::File::exists("text.map"))
++		addSource(new VolumeResourceSource("resource.tex", addExternalMap("text.map"), 0));
+ 
+ 	if (Common::File::exists("message.map"))
+ 		addSource(new VolumeResourceSource("resource.msg", addExternalMap("message.map"), 0));


### PR DESCRIPTION
추리소년님이 작업하신 시에라 한글패치 게임중 현재 ScummVM에서 지원하지 않던 게임들을 추가했습니다.

게임폴더에 한글패치 파일인 text.res 와 text.map을 같이 넣어야 합니다.

