### PR TITLE
Update wine 10.4

### DIFF
--- a/packages/compat/wine/package.mk
+++ b/packages/compat/wine/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.3"
+PKG_VERSION="10.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps
-PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-amd64.tar.xz"
+PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64-wow64.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libXcomposite libXdmcp cups"
 PKG_LONGDESC="Wine is a compatibility layer capable of running Windows applications"
 PKG_TOOLCHAIN="manual"
@@ -25,8 +25,10 @@ makeinstall_target() {
   cp -rf ${PKG_BUILD}/bin/* ${INSTALL}/usr/bin
   cp -rf ${PKG_BUILD}/lib/* ${INSTALL}/usr/lib
   cp -rf ${PKG_BUILD}/share/* ${INSTALL}/usr/share
+  rm ${INSTALL}/usr/bin/wine
+  ln -sf /usr/lib/wine/x86_64-unix/wine64 ${INSTALL}/usr/bin/wine
 
   curl -Lo ${INSTALL}/usr/bin/winetricks ${PKG_WINE_TRICKS}
 
-  chmod +x ${INSTALL}/usr/bin/*
+  chmod +x ${INSTALL}/usr/bin/winetricks
 }


### PR DESCRIPTION
wine 10.4으로 업데이트하고 
기본 wine이 아닌 패치 적용된 wine으로 변경하였습니다.

또한 winetricks가 먹히지 않던 문제 수정했습니다.

wine/bin/wine 파일에 wine_main_preload_info 정보가 없고
wine/lib/wine/x86_64-unix/wine64에 있어서 심링크 처리했습니다.

Odin2Portal에서 정상 동작하는거 확인했습니다.

WINEPREFIX=/storage/.wine64 winetricks -q dxvk vcrun2022
WINEPREFIX=/storage/.wine64 winetricks settings sound=alsa