### PR TITLE
Update box64 for Wine 10.4

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="2b300bd199a7a65a3de1eecd24d6dff5593a9b55"
+PKG_VERSION="b68d46311dba9c410ed5a9339d396486958d1e5b"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"


### PR DESCRIPTION
기존 box64버전으로 wine 10.2 이후 버전은 구동시 에러가 발생하네요.

그래서 box64를 최신버전으로 업데이트 합니다. Wine 10.4까지 에러 없이 정상 동작합니다.