### PR TITLE
Update box64

### DIFF
--- a/packages/compat/box64/package.mk
+++ b/packages/compat/box64/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="v0.3.4"
+PKG_VERSION="58021bbf42c3e5a5b1eddba0e5d649b1d91a8189"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"
-PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain ncurses SDL_sound cabextract libXss libXdmcp libXft gtk2"
 PKG_LONGDESC="Box64 lets you run x86_64 Linux programs (such as games) on non-x86_64 Linux systems, like ARM."
 PKG_TOOLCHAIN="cmake"


### PR DESCRIPTION
최신버전 wine 구동을 위해 box64 업데이트 해야됩니다.