### PR TITLE
wine 10.10 / azahar 2122 / Vulkan 1.4.313

### DIFF
--- a/packages/compat/wine/package.mk
+++ b/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="10.9"
+PKG_VERSION="10.10"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 # Use the amd64 release as it supports running both 32-bit and 64-bit windows apps

--- a/packages/emulators/standalone/azahar-sa/package.mk
+++ b/packages/emulators/standalone/azahar-sa/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="azahar-sa"
-PKG_VERSION="2122-rc2"
+PKG_VERSION="2122"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/azahar-emu/azahar"
 PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/azahar-unified-source-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,7 +6,7 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="15.1.0"
+PKG_VERSION="vulkan-sdk-1.4.313.0"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-headers/package.mk
+++ b/packages/graphics/vulkan/spirv-headers/package.mk
@@ -6,7 +6,7 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b"
+PKG_VERSION="vulkan-sdk-1.4.313.0"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/spirv-tools/package.mk
+++ b/packages/graphics/vulkan/spirv-tools/package.mk
@@ -6,7 +6,7 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="4d2f0b40bfe290dea6c6904dafdf7fd8328ba346"
+PKG_VERSION="vulkan-sdk-1.4.313.0"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/volk/package.mk
+++ b/packages/graphics/vulkan/volk/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="volk"
-PKG_VERSION="1.3.270"
+PKG_VERSION="vulkan-sdk-1.4.313.0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/zeux/volk"
 PKG_URL="https://github.com/zeux/volk/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-headers/package.mk
+++ b/packages/graphics/vulkan/vulkan-headers/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-headers"
-PKG_VERSION="1.4.317"
+PKG_VERSION="1.4.313"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Headers"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-loader/package.mk
+++ b/packages/graphics/vulkan/vulkan-loader/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-loader"
-PKG_VERSION="1.4.317"
+PKG_VERSION="1.4.313"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Loader"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-tools/package.mk
+++ b/packages/graphics/vulkan/vulkan-tools/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vulkan-tools"
-PKG_VERSION="1.4.317"
+PKG_VERSION="1.4.313"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/Vulkan-Tools"
 PKG_URL="https://github.com/KhronosGroup/Vulkan-tools/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-wsi-layer/package.mk
+++ b/packages/graphics/vulkan/vulkan-wsi-layer/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="vulkan-wsi-layer"
-PKG_VERSION="cb1a50cf7e640ad7306e673131ded98c0f133628"
+PKG_VERSION="7c71bbc21458db0f4f9c946d4b986f5e8d748aec"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/mesa/vulkan-wsi-layer"
 PKG_URL="${PKG_SITE}/-/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/vulkan-wsi-layer/patches/vklayer-driver-path.patch
+++ b/packages/graphics/vulkan/vulkan-wsi-layer/patches/vklayer-driver-path.patch
@@ -7,6 +7,6 @@ diff -rupbN vulkan-wsi-layer.orig/layer/VkLayer_window_system_integration.json v
          "type": "GLOBAL",
 -        "library_path": "./libVkLayer_window_system_integration.so",
 +        "library_path": "/usr/share/vulkan/libVkLayer_window_system_integration.so",
-         "api_version": "1.3.216",
+         "api_version": "1.4.299",
          "implementation_version": "1",
          "description": "Window system integration layer",


### PR DESCRIPTION
wine 10.10 버전이 vulkan버전에 따라 실행이 안되는 문제가 있어 1.4.313버전으로 변경했습니다.
azahar 2122 정식버전으로 업데이트 되었습니다.

SM8550에서 정상동작 확인했습니다.

modified:   packages/compat/wine/package.mk
modified:   packages/emulators/standalone/azahar-sa/package.mk
modified:   packages/graphics/vulkan/glslang/package.mk
modified:   packages/graphics/vulkan/spirv-headers/package.mk
modified:   packages/graphics/vulkan/spirv-tools/package.mk
modified:   packages/graphics/vulkan/volk/package.mk
modified:   packages/graphics/vulkan/vulkan-headers/package.mk
modified:   packages/graphics/vulkan/vulkan-loader/package.mk
modified:   packages/graphics/vulkan/vulkan-tools/package.mk
modified:   packages/graphics/vulkan/vulkan-wsi-layer/package.mk
modified:   packages/graphics/vulkan/vulkan-wsi-layer/patches/vklayer-driver-path.patch