### PR TITLE
fix ntfs error

### DIFF
--- a/packages/rocknix/sources/scripts/automount
+++ b/packages/rocknix/sources/scripts/automount
@@ -144,7 +144,7 @@ function mount_games() {
       # busybox has some weird behaviour with helpers.
       # Despite mount.ntfs is present, it is not used, so just a stupid rewrite to use newer kernel ntfs3 driver
       case ${FSTYPE} in
-        ntfs)   MOUNT_ARGS="-t ntfs3 -o iocharset=utf8" ;;
+        ntfs)   MOUNT_ARGS="-t ntfs3 -o force,iocharset=utf8" ;;
         *)      true ;;
       esac
 


### PR DESCRIPTION
ntfs 2nd SD에 문제가 생겨 인식이 안되는 경우가 발생할 때
강제로 인식하도록 수정했습니다. 
mount -t ntfs3 -o force

레포5에서 동작 확인했습니다.