### PR TITLE
Add ntfsfix

### DIFF
--- a/packages/rocknix/sources/scripts/automount
+++ b/packages/rocknix/sources/scripts/automount
@@ -164,13 +164,13 @@ function mount_games() {
         umount /var/media/* 2>/dev/null
 
         log $0 "Mounting ${1} on ${MOUNT_PATH}"
+        /usr/bin/ntfsfix -b -d ${1} >/dev/null 2>&1
         /usr/bin/busybox mount ${MOUNT_ARGS} ${1} ${MOUNT_PATH} >/dev/null 2>&1
 
         log $0 "Checking filesystem ${1}."
         if ! touch "${MOUNT_PATH}/.tmp-rocknix"; then
           log $0 "Fixing filesystem ${1}."
           /usr/bin/busybox umount ${1} >/dev/null 2>&1
-          /usr/bin/ntfsfix -b -d ${1} >/dev/null 2>&1
           /usr/sbin/fsck -Mly ${1} >/dev/null 2>&1
           /usr/bin/busybox mount ${MOUNT_ARGS} ${1} ${MOUNT_PATH} >/dev/null 2>&1
         else

--- a/packages/rocknix/sources/scripts/automount
+++ b/packages/rocknix/sources/scripts/automount
@@ -144,7 +144,7 @@ function mount_games() {
       # busybox has some weird behaviour with helpers.
       # Despite mount.ntfs is present, it is not used, so just a stupid rewrite to use newer kernel ntfs3 driver
       case ${FSTYPE} in
-        ntfs)   MOUNT_ARGS="-t ntfs3 -o force,iocharset=utf8" ;;
+        ntfs)   MOUNT_ARGS="-t ntfs3 -o iocharset=utf8" ;;
         *)      true ;;
       esac
 
@@ -170,6 +170,7 @@ function mount_games() {
         if ! touch "${MOUNT_PATH}/.tmp-rocknix"; then
           log $0 "Fixing filesystem ${1}."
           /usr/bin/busybox umount ${1} >/dev/null 2>&1
+          /usr/bin/ntfsfix -b -d ${1} >/dev/null 2>&1
           /usr/sbin/fsck -Mly ${1} >/dev/null 2>&1
           /usr/bin/busybox mount ${MOUNT_ARGS} ${1} ${MOUNT_PATH} >/dev/null 2>&1
         else

--- a/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
@@ -25,7 +25,7 @@ PKG_CONFIGURE_OPTS_TARGET="--exec-prefix=/usr/ \
 post_makeinstall_target() {
   # dont include ntfsprogs.
   for i in ${INSTALL}/usr/bin/*; do
-    if [ "$(basename ${i})" != "ntfs-3g" ]; then
+    if [[ "$(basename "${i}")" != "ntfs-3g" && "$(basename "${i}")" != "ntfsfix" ]]; then
       rm ${i}
     fi
   done


### PR DESCRIPTION
ntfs sd카드가 인식 안될때 전에는 강제로 인식 시켰으나
ntfsfix를 마운트전에 실행해서 sd카드를 체크한후 인식되게 바꾸었습니다.