### PR TITLE
Update box64/winetricks/fbneo-lr/eden-sa

### DIFF
--- a/projects/ROCKNIX/packages/compat/box64/package.mk
+++ b/projects/ROCKNIX/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="60ea78729dcda6f0e779f9b8f0f293ed77abaa7b"
+PKG_VERSION="32e2112ab04d968b13ca6561bbcb8130d9cdc7d1"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"

--- a/projects/ROCKNIX/packages/compat/wine/winetricks
+++ b/projects/ROCKNIX/packages/compat/wine/winetricks
@@ -13275,9 +13275,10 @@ load_vcrun2022()
     # 2024/10/17: ed1967c2ac27d806806d121601b526f84e497ae1b99ed139c0c4c6b50147df4a
     # 2024/11/20: dd1a8be03398367745a87a5e35bebdab00fdad080cf42af0c3f20802d08c25d4
     # 2025/03/30: c4e3992f3883005881cf3937f9e33f1c7d792ac1c860ea9c52d8f120a16a7eb1
+	# 2025/04/14: 0c09f2611660441084ce0df425c51c11e147e6447963c3690f97e0b25c55ed64
     w_override_dlls native,builtin concrt140 msvcp140 msvcp140_1 msvcp140_2 msvcp140_atomic_wait msvcp140_codecvt_ids vcamp140 vccorlib140 vcomp140 vcruntime140
 
-    w_download https://aka.ms/vs/17/release/vc_redist.x86.exe c4e3992f3883005881cf3937f9e33f1c7d792ac1c860ea9c52d8f120a16a7eb1
+    w_download https://aka.ms/vs/17/release/vc_redist.x86.exe 0c09f2611660441084ce0df425c51c11e147e6447963c3690f97e0b25c55ed64
 
     # Setup will refuse to install msvcp140 because the builtin's version number is higher, so manually replace it
     # See https://bugs.winehq.org/show_bug.cgi?id=57518
@@ -13299,10 +13300,11 @@ load_vcrun2022()
             # 2024/10/17: 814e9da5ec5e5d6a8fa701999d1fc3baddf7f3adc528e202590e9b1cb73e4a11
             # 2024/11/20: 1821577409c35b2b9505ac833e246376cc68a8262972100444010b57226f0940
             # 2025/03/30: 8f9fb1b3cfe6e5092cf1225ecd6659dab7ce50b8bf935cb79bfede1f3c895240
+			# 2025/07/14: cc0ff0eb1dc3f5188ae6300faef32bf5beeba4bdd6e8e445a9184072096b713b
             # vcruntime140_1 is only shipped on x64:
             w_override_dlls native,builtin vcruntime140_1
 
-            w_download https://aka.ms/vs/17/release/vc_redist.x64.exe 8f9fb1b3cfe6e5092cf1225ecd6659dab7ce50b8bf935cb79bfede1f3c895240
+            w_download https://aka.ms/vs/17/release/vc_redist.x64.exe cc0ff0eb1dc3f5188ae6300faef32bf5beeba4bdd6e8e445a9184072096b713b
 
             # Also replace 64-bit msvcp140.dll
             w_try_cabextract --directory="${W_TMP}/win64"  "${W_CACHE}"/"${W_PACKAGE}"/vc_redist.x64.exe -F 'a12'

--- a/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="fbneo-lr"
-PKG_VERSION="7df59d8fbb31ac5a11c3f9dc0e78c9feb52aa580"
+PKG_VERSION="43194bd45817362d6004127fe0046135e87d3e32"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/aleksei74/FBNeo"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"

--- a/projects/ROCKNIX/packages/emulators/standalone/eden-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/eden-sa/package.mk
@@ -6,15 +6,15 @@ PKG_LICENSE="GPLv3"
 PKG_LONGDESC="Eden is the world's most popular open-source Nintendo Switch emulator, forked from the Yuzu emulator."
 PKG_TOOLCHAIN="manual"
 PKG_SITE="https://github.com/pflyly/eden-nightly"
-PKG_VERSION="2025-07-18-d42d379733"
-PKG_REL_VERSION="27470"
+PKG_VERSION="2025-07-22-27482"
+PKG_REL_VERSION="27482"
 
 case ${TARGET_ARCH} in
   x86_64)
     PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/Eden-${PKG_REL_VERSION}-Common-light-x86_64_v3.AppImage"
   ;;
   aarch64)
-    PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/Eden-${PKG_REL_VERSION}-linux-light-aarch64.AppImage"
+    PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/Eden-${PKG_REL_VERSION}-Linux-light-aarch64.AppImage"
   ;;
 esac
 


### PR DESCRIPTION
Wine 10.12 구동을 위해 box64 및 winetricks 업데이트 했습니다.

fbneo-lr는 꿀렁이님이 한글화 한 매지션로드 추가입니다 (DsNo님 소스 업데이트)

eden-sa는 최신버전으로 업데이트 했습니다.