### PR TITLE
Update box64/fbneo-lr/rpcs3-sa

### DIFF
--- a/distributions/ROCKNIXK/options
+++ b/distributions/ROCKNIXK/options
@@ -122,7 +122,7 @@
   MODULES_PKG="${MODULES_PKG:-yes}"
 
 # Support for debug tools such as strace
-  DEBUG_PACKAGES="${DEBUG_PACKAGES:-yes}"
+  DEBUG_PACKAGES="${DEBUG_PACKAGES:-no}"
 
 # Windowmanager to use (weston / swaywm-env / no)
   WINDOWMANAGER="none"

--- a/projects/ROCKNIX/packages/compat/box64/package.mk
+++ b/projects/ROCKNIX/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="32e2112ab04d968b13ca6561bbcb8130d9cdc7d1"
+PKG_VERSION="f7302ecb1b08831037cb067bd62863b90768604a"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"

--- a/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="fbneo-lr"
-PKG_VERSION="43194bd45817362d6004127fe0046135e87d3e32"
+PKG_VERSION="1b5b5f848f01c006341575d4ee2d1b7379ab43c4"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/aleksei74/FBNeo"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"

--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -7,8 +7,8 @@ PKG_SITE="https://github.com/RPCS3/rpcs3-binaries-linux"
 PKG_DEPENDS_TARGET="toolchain libevdev SDL2 qt6 mesa libcom-err"
 PKG_LONGDESC="PS3 Emulator appimage"
 PKG_TOOLCHAIN="manual"
-PKG_VERSION="46150322a3089a8f5664094e8f2d15bc1fd3594e"
-PKG_REL_VERSION="0.0.37-18070-46150322"
+PKG_VERSION="e319ca299820cb4009386059f2ba830a9b698274"
+PKG_REL_VERSION="0.0.37-18090-e319ca29"
 
 case ${TARGET_ARCH} in
   x86_64)


### PR DESCRIPTION
어제자 dsno님 fbneo 업데이트 및 box64/rpcs3 최신버전으로 업데이트 했습니다.
오딘2에서 정상동작 확인했습니다.

디버그는 빼는게 퍼포먼스면에서 좋을거 같아 뺀건데 확인하시고 문제 있다면 원복하셔도 됩니다.