### PR TITLE
Update RetroArch GIT_VERSION

### DIFF
--- a/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/fbneo-lr/package.mk
@@ -16,7 +16,7 @@ PKG_TOOLCHAIN="make"
 pre_configure_target() {
 sed -i "s|LDFLAGS += -static-libgcc -static-libstdc++|LDFLAGS += -static-libgcc|"  ./src/burner/libretro/Makefile
 
-PKG_MAKE_OPTS_TARGET=" -C ./src/burner/libretro USE_CYCLONE=0 profile=performance"
+PKG_MAKE_OPTS_TARGET=" -C ./src/burner/libretro USE_CYCLONE=0 profile=performance GIT_VERSION=$(echo ${PKG_VERSION} | head -c 10)"
 
 if [[ "${TARGET_FPU}" =~ "neon" ]]; then
 	PKG_MAKE_OPTS_TARGET+=" HAVE_NEON=1"

--- a/projects/ROCKNIX/packages/emulators/libretro/mame-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/mame-lr/package.mk
@@ -41,6 +41,7 @@ PKG_MAKE_OPTS_TARGET="REGENIE=1 \
 		      TARGET=mame \
 		      SUBTARGET=arcade \
 		      IGNORE_GIT=0 \
+		      NEW_GIT_VERSION=$(echo ${PKG_VERSION} | head -c 10) \
 		      OSD=retro \
 		      USE_SYSTEM_LIB_EXPAT=1 \
 		      USE_SYSTEM_LIB_ZLIB=1 \

--- a/projects/ROCKNIX/packages/emulators/libretro/mame2003-plus-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/mame2003-plus-lr/package.mk
@@ -31,7 +31,7 @@ PKG_LONGDESC="MAME - Multiple Arcade Machine Emulator"
 PKG_TOOLCHAIN="make"
 
 make_target() {
-  make ARCH="" CC="${CC}" NATIVE_CC="${CC}" LD="${CC}"
+  make ARCH="" CC="${CC}" NATIVE_CC="${CC}" LD="${CC}" GIT_VERSION=$(echo ${PKG_VERSION} | head -c 10)
 }
 
 makeinstall_target() {

--- a/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/retroarch/package.mk
@@ -107,7 +107,7 @@ pre_build_target() {
 }
 
 make_target() {
-  make HAVE_UPDATE_ASSETS=0 HAVE_LIBRETRODB=1 HAVE_BLUETOOTH=0 HAVE_NETWORKING=1 HAVE_ZARCH=1 HAVE_QT=0 HAVE_LANGEXTRA=1
+  make HAVE_UPDATE_ASSETS=0 HAVE_LIBRETRODB=1 HAVE_BLUETOOTH=0 HAVE_NETWORKING=1 HAVE_ZARCH=1 HAVE_QT=0 HAVE_LANGEXTRA=1 GIT_VERSION=$(echo ${PKG_VERSION} | head -c 10)
   [ $? -eq 0 ] && echo "(retroarch ok)" || { echo "(retroarch failed)" ; exit 1 ; }
   make -C gfx/video_filters compiler=$CC extra_flags="$CFLAGS"
   [ $? -eq 0 ] && echo "(video filters ok)" || { echo "(video filters failed)" ; exit 1 ; }


### PR DESCRIPTION
레트로아크 및 각 코어의 버전이 제대로 표시 될수 있도록 수정했습니다.

PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz" 으로 소스를 다운로드 할 경우 제대로 Git Version을 표시하지 못해서

${PKG_VERSION}을 이용해서 제대로 표시 할수 있도록 수정했습니다.

우선 retroarch/fbneo-lr/mame2003-plus-lr/mame-lr 변경했습니다.