### PR TITLE
Fix SDL2_glesonly

### DIFF
--- a/projects/ROCKNIX/packages/virtual/image/package.mk
+++ b/projects/ROCKNIX/packages/virtual/image/package.mk
@@ -15,6 +15,12 @@ PKG_DEPENDS_TARGET="toolchain squashfs-tools:host dosfstools:host fakeroot:host 
                     bash coreutils system-utils autostart quirks powerstate gnupg \
                     gzip six xmlstarlet pyudev dialog dbus-python network rocknix"
 
+case "${DEVICE}" in
+  RK*)
+    PKG_DEPENDS_TARGET+=" SDL2_glesonly"
+  ;;
+esac
+
 PKG_UI="emulationstation es-themes textviewer"
 
 PKG_UI_TOOLS="fbgrab grim"


### PR DESCRIPTION
SDL2_glesonly 가 제대로 설치가 되지 않아서 따로 패키지 설치되도록 수정했습니다.

이걸로 libmali에서 fileman portmaster scummvm 실행안되는 문제를 해결했습니다.