### PR TITLE
Fix ppsspp_font.sh

### DIFF
--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -69,9 +69,11 @@ makeinstall_target() {
   cp ${PKG_BUILD}/start_es.sh ${INSTALL}/usr/bin
   chmod 0755 ${INSTALL}/usr/bin/start_es.sh
 
+  cp ${PKG_BUILD}/ppsspp_font.sh ${INSTALL}/usr/bin
+  chmod 0755 ${INSTALL}/usr/bin/ppsspp_font.sh
+
   cp ${PKG_BUILD}/serial_number_check ${INSTALL}/usr/bin
   chmod 0755 ${INSTALL}/usr/bin/serial_number_check
-  chmod 0755 ${INSTALL}/usr/bin/ppsspp_font.sh
 
   mkdir -p ${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}
   cp -rf ${PKG_DIR}/bluez/* ${INSTALL}/usr/lib/${PKG_PYTHON_VERSION}


### PR DESCRIPTION
업데이트 되면서 ppsspp_font.sh 복사구문이 빠졌네요.