### PR TITLE
Update citron/eden/rpcs3/es

### DIFF
--- a/projects/ROCKNIX/packages/compat/box64/package.mk
+++ b/projects/ROCKNIX/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="e8ed70905c73a7d4c1c0ef6f099f6b1c4e208e96"
+PKG_VERSION="89e5c644d070163383bf4f892333ec84352d776b"
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"

--- a/projects/ROCKNIX/packages/emulators/standalone/citron-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/citron-sa/package.mk
@@ -8,7 +8,7 @@ PKG_LONGDESC="Citron is a high-performance and easy-to-use emulator, tailored fo
 PKG_TOOLCHAIN="cmake"
 PKG_SITE="https://git.citron-emu.org/citron/emulator"
 PKG_URL="${PKG_SITE}.git"
-PKG_VERSION="39451afd59aacf0dba235774395df4338b1ba4dc"
+PKG_VERSION="df14b96c6b6e877f44eb5a18f3d15a1b9946dc7e"
 
 if [ ! "${OPENGL}" = "no" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL} glu libglvnd"
@@ -36,6 +36,8 @@ PKG_CMAKE_OPTS_TARGET+="-DENABLE_QT=ON \
                     -DCITRON_TESTS=OFF \
                     -DENABLE_WEB_SERVICE=OFF \
                     -DCITRON_DOWNLOAD_ANDROID_VVL=OFF \
+                    -DCITRON_ENABLE_PGO_USE=ON \
+                    -DCITRON_ENABLE_LTO=ON \
                     -DCITRON_ENABLE_PORTABLE=OFF"
 
 makeinstall_target() {

--- a/projects/ROCKNIX/packages/emulators/standalone/eden-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/eden-sa/package.mk
@@ -6,8 +6,8 @@ PKG_LICENSE="GPLv3"
 PKG_LONGDESC="Eden is the world's most popular open-source Nintendo Switch emulator, forked from the Yuzu emulator."
 PKG_TOOLCHAIN="manual"
 PKG_SITE="https://github.com/pflyly/eden-nightly"
-PKG_VERSION="2025-10-07-27794"
-PKG_REL_VERSION="27794"
+PKG_VERSION="2025-10-11-27807"
+PKG_REL_VERSION="27807"
 
 case ${TARGET_ARCH} in
   x86_64)

--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -7,8 +7,8 @@ PKG_SITE="https://github.com/RPCS3/rpcs3-binaries-linux"
 PKG_DEPENDS_TARGET="toolchain libevdev SDL2 qt6 mesa libcom-err"
 PKG_LONGDESC="PS3 Emulator appimage"
 PKG_TOOLCHAIN="manual"
-PKG_VERSION="48bf30aa2d82e18933ddac2464a1007082e7351a"
-PKG_REL_VERSION="0.0.38-18178-48bf30aa"
+PKG_VERSION="9e49b9100fab7293c5f616f6aebc91799461c26c"
+PKG_REL_VERSION="0.0.38-18185-9e49b910"
 
 case ${TARGET_ARCH} in
   x86_64)

--- a/projects/ROCKNIX/packages/ui/emulationstation/package.mk
+++ b/projects/ROCKNIX/packages/ui/emulationstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present ROCKNIX (https://github.com/ROCKNIX)
 
 PKG_NAME="emulationstation"
-PKG_VERSION="9c458a702e50f62e088e8734e71128bb071c7b4a"
+PKG_VERSION="a081efb94a734fb788bb9286f071647a7765d80b"
 PKG_GIT_CLONE_BRANCH="master"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/ROCKNIX/emulationstation-next"


### PR DESCRIPTION
citron 0.8.0
eden/rpcs3 최신버전으로 업데이트
ES 문제로 전버전으로 롤백했어요.