### PR TITLE
Fix grub config file

### DIFF
--- a/projects/ROCKNIX/packages/tools/grub/package.mk
+++ b/projects/ROCKNIX/packages/tools/grub/package.mk
@@ -74,7 +74,7 @@ makeinstall_target() {
     search_label chain reboot loadenv test gfxterm efi_gop
 
   mkdir -p ${INSTALL}/usr/share/bootloader/EFI/BOOT
-  #cp -av ${PKG_DIR}/config/* ${INSTALL}/usr/share/bootloader/EFI/BOOT
+  cp -av ${PKG_DIR}/config/* ${INSTALL}/usr/share/bootloader/EFI/BOOT
   cp -av bootaa64.efi ${INSTALL}/usr/share/bootloader/EFI/BOOT
 
   # Create grub configuration
@@ -82,8 +82,4 @@ makeinstall_target() {
 
   # Always install the update script
   find_file_path bootloader/update.sh && cp -av ${FOUND_PATH} ${INSTALL}/usr/share/bootloader
-
-  if [ -d ${PKG_DIR}/sources/${DEVICE} ]; then
-    cp -av ${PKG_DIR}/sources/${DEVICE}/* ${INSTALL}/usr/share/bootloader/EFI/BOOT
-  fi
 }


### PR DESCRIPTION
업데이트 하면서 grub 파일 복사하는게 누락 되면서 grub 폰트와 저장파일이 없어 문제가 발생했습니다.
공식버전 보고 확인해본 결과 수정하면 정상동작할것으로 보입니다.