### PR TITLE
Fix mesa for SM8550

### DIFF
--- a/projects/ROCKNIX/packages/graphics/mesa/package.mk
+++ b/projects/ROCKNIX/packages/graphics/mesa/package.mk
@@ -12,7 +12,14 @@ PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host pyyaml:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 PKG_TOOLCHAIN="meson"
 PKG_PATCH_DIRS+=" ${DEVICE}"
-PKG_VERSION="25.3.2"
+case ${DEVICE} in
+  SM8550)
+    PKG_VERSION="25.2.8"
+  ;;
+  *)
+    PKG_VERSION="25.3.2"
+  ;;
+esac
 PKG_URL="https://gitlab.freedesktop.org/mesa/mesa/-/archive/mesa-${PKG_VERSION}/mesa-mesa-${PKG_VERSION}.tar.gz"
 
 if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then


### PR DESCRIPTION
mesa 25.3.x버전에서 오딘2등 vulkan이 동작안되는 버그가 있어 25.2.x버전으로 내립니다.