### PR TITLE
Fix citron-sa for QT6

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/citron-sa/patches/06-fix-boost.patch
+++ b/projects/ROCKNIX/packages/emulators/standalone/citron-sa/patches/06-fix-boost.patch
@@ -11,12 +11,3 @@ index b7841c69b..bc21d74c4 100644
  if (MSVC)
      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++20>)
 
-@@ -569,7 +569,7 @@ function(set_citron_qt_components)
- # Best practice is to ask for all components at once, so they are from the same version
- set(CITRON_QT_COMPONENTS2 Core Widgets Concurrent)
- if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
--list(APPEND CITRON_QT_COMPONENTS2 DBus GuiPrivate)
-+list(APPEND CITRON_QT_COMPONENTS2 DBus Gui)
- endif()
- if (CITRON_USE_QT_MULTIMEDIA)
- list(APPEND CITRON_QT_COMPONENTS2 Multimedia)


### PR DESCRIPTION
Fixes the list of Qt components for Linux by changing 'GuiPrivate' to 'Gui'.