### PR TITLE
Update box64/wine/rpcs3/scummvm/gstreamer

### DIFF
--- a/projects/ROCKNIX/packages/compat/box64/package.mk
+++ b/projects/ROCKNIX/packages/compat/box64/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="box64"
-PKG_VERSION="d8bb64b14739c1f19946bd464840969424e076b2" #260214
+PKG_VERSION="1ce47890c91426380ea65167719f6379903e25b8" #260310
 PKG_ARCH="aarch64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ptitSeb/box64"
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain ncurses SDL2 cabextract libXss libXdmcp libXft gtk
 PKG_LONGDESC="Box64 lets you run x86_64 Linux programs (such as games) on non-x86_64 Linux systems, like ARM."
 PKG_TOOLCHAIN="cmake"
 
-PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=Release"
+PKG_CMAKE_OPTS_TARGET="-DBOX32_BINFMT=ON -DBOX32=ON -DARM_DYNAREC=ON"
 
 case ${DEVICE} in
   RK3588)

--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="11.3"
+PKG_VERSION="11.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64-wow64.tar.xz"

--- a/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/rpcs3-sa/package.mk
@@ -7,8 +7,8 @@ PKG_SITE="https://github.com/RPCS3/rpcs3-binaries-linux"
 PKG_DEPENDS_TARGET="toolchain libevdev SDL2 qt6 mesa libcom-err"
 PKG_LONGDESC="PS3 Emulator appimage"
 PKG_TOOLCHAIN="manual"
-PKG_VERSION="86b2773c2854ede00ff376d1ee82898c74eb8b71"
-PKG_REL_VERSION="0.0.40-18874-86b2773c"
+PKG_VERSION="e6cf05cfb73e156818685495814b0b7b8edaa97b"
+PKG_REL_VERSION="0.0.40-18945-e6cf05cf"
 
 case ${TARGET_ARCH} in
   x86_64)

--- a/projects/ROCKNIX/packages/emulators/standalone/scummvmsa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/scummvmsa/package.mk
@@ -6,7 +6,7 @@ PKG_NAME="scummvmsa"
 PKG_VERSION="2026.1.0"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://github.com/scummvm/scummvm"
-PKG_URL="${PKG_SITE}.git"
+PKG_URL="${PKG_SITE}/archive/refs/tags/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain SDL2 SDL2_net freetype fluidsynth soundfont-generaluser pipewire libmad libtheora faad2"
 PKG_LONGDESC="Script Creation Utility for Maniac Mansion Virtual Machine"
 

--- a/projects/ROCKNIX/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
+++ b/projects/ROCKNIX/packages/multimedia/gstreamer/gst-plugins-bad/package.mk
@@ -7,12 +7,12 @@ PKG_VERSION="$(get_pkg_version gstreamer)"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html"
 PKG_URL="https://gstreamer.freedesktop.org/src/gst-plugins-bad/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain gstreamer gst-plugins-base faad2"
+PKG_DEPENDS_TARGET="toolchain gstreamer gst-plugins-base"
 PKG_LONGDESC="GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared to the rest."
 
 PKG_MESON_OPTS_TARGET="-Dgst_play_tests=false \
                          -Dwebp=disabled \
-                         -Dfaad=enabled \
+                         -Dbluez=disabled \
                          -Dgpl=enabled \
                          -Dhls=disabled \
                          -Dsctp-internal-usrsctp=disabled \

--- a/projects/ROCKNIX/packages/multimedia/gstreamer/gstreamer/package.mk
+++ b/projects/ROCKNIX/packages/multimedia/gstreamer/gstreamer/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gstreamer"
-PKG_VERSION="1.26.10"
+PKG_VERSION="1.28.1"
 PKG_LICENSE="GPL-2.1-or-later"
 PKG_SITE="https://gstreamer.freedesktop.org"
 PKG_URL="https://gstreamer.freedesktop.org/src/gstreamer/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
wine 11.4
box64 ALSA버그 수정된 버전
gstreamer 최신버전으로 업데이트 v4l2 지원
rpcs3 최신버전
scummvm .git이 아닌 tar.gz로 소스 다운로드 수정
