### PR TITLE
Update mame-lr/wine

### DIFF
--- a/projects/ROCKNIX/packages/compat/wine/package.mk
+++ b/projects/ROCKNIX/packages/compat/wine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-present JELOS (https://github.com/JustEnoughLinuxOS)
 
 PKG_NAME="wine"
-PKG_VERSION="11.5"
+PKG_VERSION="11.4"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/Kron4ek/Wine-Builds"
 PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/wine-${PKG_VERSION}-staging-tkg-amd64-wow64.tar.xz"

--- a/projects/ROCKNIX/packages/emulators/libretro/mame-lr/package.mk
+++ b/projects/ROCKNIX/packages/emulators/libretro/mame-lr/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Trond Haugland (trondah@gmail.com)
 
 PKG_NAME="mame-lr"
-PKG_VERSION="74731455f45c08d4f303c6d07c4f1cbf791d52b6" # lrmame 0.286
+PKG_VERSION="dd2bcd1dae606dbb15859d699d435b70bf9e755e" # lrmame 0.287
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame"
 PKG_URL="https://github.com/libretro/mame/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
mame-lr 0.287 
wine 11.4 로 내립니다. 11.5가 제대로 동작하지 않네요.