### PR TITLE
pcsx2: fix game patches never applying (use flat release asset)

### DIFF
--- a/projects/ROCKNIX/packages/emulators/standalone/pcsx2-sa/package.mk
+++ b/projects/ROCKNIX/packages/emulators/standalone/pcsx2-sa/package.mk
@@ -22,7 +22,12 @@ PCSX2_CMAKE_BASE=(
   -DX11_API=ON
 )
 
-PATCHES_URL="https://github.com/PCSX2/pcsx2_patches/archive/refs/tags/latest.zip"
+# Use the release asset, not the "latest" source archive. The source archive
+# nests every pnach under "pcsx2_patches-latest/patches/", but PCSX2 looks
+# patches up at the zip root as "<serial>_<crc>.pnach" (Patch.cpp:
+# GetPnachTemplate has no directory prefix), so those never match. The release
+# asset ships the pnach files flat at the root, as PCSX2 expects.
+PATCHES_URL="https://github.com/PCSX2/pcsx2_patches/releases/download/latest/patches.zip"
 
 # RK3576's Cortex-A72 is ARMv8.0-A and lacks LSE atomics; PCSX2's default
 # -march=armv8.1-a emits LSE instructions that SIGILL on it. Drop to armv8-a


### PR DESCRIPTION
PCSX2 looks patches up at the root of resources/patches.zip as "<serial>_<crc>.pnach" (Patch.cpp: GetPnachTemplate has no directory prefix). The package fetched the pcsx2_patches "latest" GitHub *source* archive, which nests every pnach under "pcsx2_patches-latest/patches/", so nothing ever matched and widescreen/compat patches silently did nothing.

Point PATCHES_URL at the release asset instead, which ships the pnach files flat at the zip root (no .github/README junk, deflate-compressed), exactly the layout PCSX2 and the armsx2 upstream bundle expect.

Verified on-device by bind-mounting a root-flat patches.zip over the read-only one: patches apply.

## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES
