### PR TITLE
qt6: pin v6.8.3 on RK3566

### DIFF
--- a/projects/ROCKNIX/packages/graphics/qt6/package.mk
+++ b/projects/ROCKNIX/packages/graphics/qt6/package.mk
@@ -7,8 +7,19 @@ PKG_SITE="https://download.qt.io"
 PKG_DEPENDS_TARGET="toolchain qt6:host openssl libjpeg-turbo libpng pcre2 sqlite zlib freetype SDL2 gstreamer gst-plugins-base gst-plugins-good gst-libav"
 PKG_DEPENDS_HOST="gcc:host llvm:host mesa:host"
 PKG_LONGDESC="A cross-platform application and UI framework"
-PKG_VERSION_MAJOR="6.10"
-PKG_VERSION="${PKG_VERSION_MAJOR}.3"
+
+# RK3566 requires Qt v6.8.3 or azahar-sa will segfault in dual-window mode
+case ${DEVICE} in
+  RK3566)
+    PKG_VERSION_MAJOR="6.8"
+    PKG_VERSION="${PKG_VERSION_MAJOR}.3"
+  ;;
+  *)
+    PKG_VERSION_MAJOR="6.10"
+    PKG_VERSION="${PKG_VERSION_MAJOR}.3"
+  ;;
+esac
+
 PKG_URL="${PKG_SITE}/archive/qt/${PKG_VERSION_MAJOR}/${PKG_VERSION}/single/qt-everywhere-src-${PKG_VERSION}.tar.xz"
 
 # Apply project-specific patches


### PR DESCRIPTION
Qt 6.10 causes azahar-sa to segfault in dual-window mode on RK3566. Pin Qt 6.8.3 only for RK3566 while retaining Qt 6.10.3 for all other platforms.

## Summary

* **What is the goal of this PR?** (e.g. Bump up an emulator version, implement a new feature. )

## Testing

* **How was this tested?** (e.g. Built and tested on specific devices, manual testing steps, URLs for CI/CD build artifacts.)
* **Test results:** (e.g. Screenshots, logs, performance metrics if applicable.)

## Additional Context

* **Add any other information that might be helpful for the reviewer** (e.g., performance implications, potential risks, specific areas to focus on.)

---

### AI Usage

While ROCKNIX doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?** YES | PARTIALLY | NO
